### PR TITLE
feat: env文件路径分隔符 & 构建配置env文件名逻辑调整

### DIFF
--- a/harmony/config/hvigorfile.ts
+++ b/harmony/config/hvigorfile.ts
@@ -5,6 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 function loadEnvFileToMap(fileName: string): Map<string, string> {
+  console.log(`loadEnvFileToMap:fileName=${fileName}`)
   if (fs.existsSync(fileName)) {
     const envFilePath = path.resolve(__dirname, fileName);
     const envFileContent = fs.readFileSync(envFilePath, 'utf8');
@@ -54,19 +55,19 @@ export function defineBuildConfig() {
           const appContext = node.getContext(OhosPluginId.OHOS_APP_PLUGIN) as OhosAppContext;
           const buildMode =  appContext.getBuildMode()
           const extParams = hvigor.getParameter().getExtParams();
-          let configFile = ".env"
-          try{
-            configFile = appContext.getBuildProfileOpt().app.products[0].buildOption.arkOptions.buildProfileFields[buildMode]
-          }catch{
-            console.log('buildProfileFields is not find buildMode');
-          }
-          if (process.env.ENVFILE) {
+          const buildProfileEnvFile = appContext.getBuildProfileOpt()?.app?.products[0]?.buildOption?.arkOptions?.buildProfileFields[`env_file_${buildMode}`];
+          let configFile;
+          if(process.env.ENVFILE) {
             configFile = process.env.ENVFILE;
+            console.log(`configFile=${configFile}, from process.env.ENVFILE`);
+          } else if (buildProfileEnvFile) {
+            configFile = buildProfileEnvFile;
+            console.log(`configFile=${configFile}, from buildProfileFields[env_file_${buildMode}]`);
+          } else {
+            configFile = ".env"
+            console.log(`configFile=${configFile}, from default`);
           }
-          console.log(configFile);
-          console.log(conPath + '\\' + configFile);
-
-          generateConfigClass(loadEnvFileToMap(conPath + '\\' + configFile));
+          generateConfigClass(loadEnvFileToMap(conPath + path.sep + configFile));
         },
 
         dependencies: ['default@PreBuild'],


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：
- 在使用过程中遇到了**issue#6** 一样的问题，**在mac上文件路径不对**（目录分隔符使用的是windows系统上的 \ ），同时还发现了**env优先级问题** & buildProfileFields 配置的key不合理情况；

## Test Plan

我自己mac上测试没问题；
包括文件路径问题，env 优先级问题，及 buildProfileFields key 不合理问题；

